### PR TITLE
Clean up portfolio layout, loader, and analytics setup

### DIFF
--- a/app/components/DynamicProjectCard.jsx
+++ b/app/components/DynamicProjectCard.jsx
@@ -2379,7 +2379,7 @@ const DynamicProjectCard = ({ project }) => {
               </div>
 
               <div ref={descriptionGroupRef} className="max-w-[600px]">
-                <p className="xtext-sm lg:text-md opacity-85 leading-snug text-pretty">
+                <p className="text-sm lg:text-md opacity-85 leading-snug text-pretty">
                   {description}
                 </p>
               </div>

--- a/app/components/HeroSection.tsx
+++ b/app/components/HeroSection.tsx
@@ -1,38 +1,41 @@
 "use client";
 import { MapPin, Volume2 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import Image from "next/image";
 import gsap from "gsap";
 
 export default function Hero() {
-  const [isClient, setIsClient] = useState(false);
   const definitionRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setIsClient(true);
-
-    if (definitionRef.current) {
-      const tl = gsap.timeline({
-        delay: 3.5,
-        defaults: { ease: "expo.out", duration: 1.4 },
-      });
-
-      tl.fromTo(
-        definitionRef.current,
-        {
-          clipPath: "inset(100% 0% 0% 0%)",
-          opacity: 0,
-          y: 30,
-          scale: 0.98,
-        },
-        {
-          clipPath: "inset(0% 0% 0% 0%)",
-          opacity: 1,
-          y: 0,
-          scale: 1,
-        }
-      );
+    if (!definitionRef.current) {
+      return;
     }
+
+    const animation = gsap.timeline({
+      delay: 3.5,
+      defaults: { ease: "expo.out", duration: 1.4 },
+    });
+
+    animation.fromTo(
+      definitionRef.current,
+      {
+        clipPath: "inset(100% 0% 0% 0%)",
+        opacity: 0,
+        y: 30,
+        scale: 0.98,
+      },
+      {
+        clipPath: "inset(0% 0% 0% 0%)",
+        opacity: 1,
+        y: 0,
+        scale: 1,
+      }
+    );
+
+    return () => {
+      animation.kill();
+    };
   }, []);
 
   return (
@@ -44,7 +47,7 @@ export default function Hero() {
       <div className="absolute top-6 right-6 z-20">
         <a
           href="mailto:raunaqbansal11@gmail.com?subject=Let's%20Get%20In%20Touch&body=Hello%2C%20I'd%20like%20to%20connect."
-          className="bg-[#355E3B] text-white px-4 py-2 text-xs rounded transition-all duration-300 ease-in-out xhover:text-black "
+          className="bg-[#355E3B] text-white px-4 py-2 text-xs rounded transition-all duration-300 ease-in-out hover:text-black"
         >
           Get in touch
         </a>

--- a/app/components/Loader.jsx
+++ b/app/components/Loader.jsx
@@ -11,11 +11,11 @@ export default function Loader({ onComplete }) {
   const logoRef = useRef(null);
   const progressBarRef = useRef(null);
 
-  // Shorter minimum display time
+  // Short minimum display time before we allow the loader to dismiss
   useEffect(() => {
     const minDisplayTimer = setTimeout(() => {
       setIsReadyToExit(true);
-    }, 1500); // Reduced to 2.5 seconds
+    }, 1500); // 1.5 seconds
 
     return () => clearTimeout(minDisplayTimer);
   }, []);
@@ -40,52 +40,62 @@ export default function Loader({ onComplete }) {
 
   // Animation when progress reaches 100% AND minimum time has passed
   useEffect(() => {
-    if (progress >= 99 && isReadyToExit) {
-      // Create exit animation
-      const tl = gsap.timeline({
-        onComplete: () => {
-          if (onComplete) {
-            onComplete();
-          }
+    if (progress < 99 || !isReadyToExit) {
+      return;
+    }
+
+    // Create exit animation
+    const timeline = gsap.timeline({
+      onComplete: () => {
+        if (onComplete) {
+          onComplete();
         }
-      });
+      },
+    });
 
-      // Complete the progress bar
-      tl.to(progressBarRef.current, {
-        width: "100%",
-        duration: 0.15,
-        ease: "power2.out"
-      });
-      
-      // Brief pause
-      tl.to({}, { duration: 0.3 });
-      
-      // Scale and fade out the logo
-      tl.to(logoRef.current, {
-        y: -20,
-        opacity: 0,
-        duration: 0.5,
-        ease: "power2.out"
-      });
+    // Complete the progress bar
+    timeline.to(progressBarRef.current, {
+      width: "100%",
+      duration: 0.15,
+      ease: "power2.out",
+    });
 
-      // Slide up the entire overlay
-      tl.to(overlayRef.current, {
+    // Brief pause
+    timeline.to({}, { duration: 0.3 });
+
+    // Scale and fade out the logo
+    timeline.to(logoRef.current, {
+      y: -20,
+      opacity: 0,
+      duration: 0.5,
+      ease: "power2.out",
+    });
+
+    // Slide up the entire overlay
+    timeline.to(
+      overlayRef.current,
+      {
         y: "-100%",
         duration: 0.7,
         ease: "power3.inOut",
-      }, "-=0.3");
+      },
+      "-=0.3"
+    );
 
-      // Finally hide the container
-      tl.to(containerRef.current, {
-        opacity: 0,
-        duration: 0.15,
-        onComplete: () => {
-          if (containerRef.current) {
-            containerRef.current.style.display = "none";
-          }
+    // Finally hide the container
+    timeline.to(containerRef.current, {
+      opacity: 0,
+      duration: 0.15,
+      onComplete: () => {
+        if (containerRef.current) {
+          containerRef.current.style.display = "none";
         }
-      });
-    }
+      },
+    });
+
+    return () => {
+      timeline.kill();
+    };
   }, [progress, isReadyToExit, onComplete]);
 
   // Initial animation on mount
@@ -140,9 +150,9 @@ export default function Loader({ onComplete }) {
             <div 
               ref={progressBarRef}
               className="h-full transition-all duration-100 ease-out"
-              style={{ 
+              style={{
                 width: `${progress}%`,
-                backgroundColor: '#fcfcfc'
+                backgroundColor: "#fcfcfc",
               }}
             />
           </div>
@@ -151,138 +161,3 @@ export default function Loader({ onComplete }) {
     </div>
   );
 }
-
-
-
-
-// was using the first loader on this page before btw
-// // components/Loader.jsx
-// "use client";
-// import { useEffect, useRef, useState } from "react";
-// import { gsap } from "gsap";
-
-// export default function Loader({ onComplete }) {
-//   const [progress, setProgress] = useState(0);
-//   const [isReadyToExit, setIsReadyToExit] = useState(false);
-//   const containerRef = useRef(null);
-//   const overlayRef = useRef(null);
-//   const logoRef = useRef(null);
-
-//   // Very short display time
-//   useEffect(() => {
-//     const minDisplayTimer = setTimeout(() => {
-//       setIsReadyToExit(true);
-//     }, 2000); // Just 2 seconds
-
-//     return () => clearTimeout(minDisplayTimer);
-//   }, []);
-
-//   // Handle the progress animation with GSAP
-//   useEffect(() => {
-//     // Create a smoother progress animation using GSAP
-//     const progressTween = gsap.to({}, {
-//       duration: 1.6, // Even faster
-//       onUpdate: function() {
-//         // Calculate progress based on timeline position
-//         const newProgress = Math.min(100, this.progress() * 100);
-//         setProgress(newProgress);
-//       },
-//       ease: "power1.out",
-//     });
-
-//     return () => {
-//       progressTween.kill();
-//     };
-//   }, []);
-
-//   // Animation when progress reaches 100% AND minimum time has passed
-//   useEffect(() => {
-//     if (progress >= 99 && isReadyToExit) {
-//       // Create exit animation
-//       const tl = gsap.timeline({
-//         onComplete: () => {
-//           if (onComplete) {
-//             onComplete();
-//           }
-//         }
-//       });
-      
-//       // Fade out the logo with a slight scale up
-//       tl.to(logoRef.current, {
-//         scale: 1.05,
-//         opacity: 0,
-//         duration: 0.5,
-//         ease: "power2.inOut"
-//       });
-
-//       // Slide up the entire overlay
-//       tl.to(overlayRef.current, {
-//         y: "-100%",
-//         duration: 0.6,
-//         ease: "power2.inOut",
-//       }, "-=0.3");
-
-//       // Finally hide the container
-//       tl.to(containerRef.current, {
-//         opacity: 0,
-//         duration: 0.1,
-//         onComplete: () => {
-//           if (containerRef.current) {
-//             containerRef.current.style.display = "none";
-//           }
-//         }
-//       });
-//     }
-//   }, [progress, isReadyToExit, onComplete]);
-
-//   // Initial animation on mount
-//   useEffect(() => {
-//     const tl = gsap.timeline();
-    
-//     // Simple fade in for logo
-//     tl.from(logoRef.current, {
-//       scale: 0.95,
-//       opacity: 0,
-//       duration: 0.7,
-//       ease: "power2.out"
-//     });
-//   }, []);
-
-//   return (
-//     <div 
-//       ref={containerRef}
-//       className="fixed top-0 left-0 w-full h-full z-[100000]"
-//       style={{ pointerEvents: "all" }}
-//     >
-//       {/* Simple dark background */}
-//       <div 
-//         ref={overlayRef}
-//         className="absolute inset-0 w-full h-full bg-[#171717] z-10"
-//       />
-
-//       {/* Centered content */}
-//       <div className="relative z-30 w-full h-full flex items-center justify-center">
-//         {/* Logo with subtle pulse animation */}
-//         <div 
-//           ref={logoRef} 
-//           className="transform"
-//           style={{
-//             animation: progress < 99 ? 'subtle-pulse 2s infinite alternate' : 'none'
-//           }}
-//         >
-//           <style jsx>{`
-//             @keyframes subtle-pulse {
-//               0% { opacity: 0.9; transform: scale(1); }
-//               100% { opacity: 1; transform: scale(1.02); }
-//             }
-//           `}</style>
-//           <img
-//             src="/assets/logo-grey-rise.png" 
-//             alt="Raunaq" 
-//             className="h-20 md:h-24"
-//           />
-//         </div>
-//       </div>
-//     </div>
-//   );
-// }

--- a/app/components/LoaderWrapper.jsx
+++ b/app/components/LoaderWrapper.jsx
@@ -1,35 +1,28 @@
-// components/LoaderWrapper.jsx
 "use client";
-import { useState, useEffect } from 'react';
-import Loader from './Loader';
+import { useState, useEffect } from "react";
+import Loader from "./Loader";
 
 export default function LoaderWrapper({ children, forceShow = false }) {
   const [loading, setLoading] = useState(true);
   const [initialRender, setInitialRender] = useState(true);
-  
+
   // Use useEffect to safely check session storage on client-side
   useEffect(() => {
     // Mark that we've completed initial render
     setInitialRender(false);
-    
+
     // If forceShow is true, always show the loader (for testing)
     if (forceShow) {
-      console.log("Force showing loader for testing");
       return;
     }
-    
+
     try {
       // Check if the loader has been shown in this session
       const loaderShown = sessionStorage.getItem("loaderShown");
-      
+
       if (loaderShown === "true") {
         // Returning visitor, skip loader
-        console.log("Loader already shown in this session, skipping");
         setLoading(false);
-      } else {
-        // First visit in this session, show the loader
-        console.log("First visit in session, showing loader");
-        // We'll set this flag when loader completes
       }
     } catch (error) {
       // In case of private browsing mode or other sessionStorage issues
@@ -39,7 +32,6 @@ export default function LoaderWrapper({ children, forceShow = false }) {
   }, [forceShow]);
 
   const handleLoadingComplete = () => {
-    console.log("Loader complete callback triggered");
     if (!forceShow) {
       try {
         // Mark that we've shown the loader in this session
@@ -60,9 +52,9 @@ export default function LoaderWrapper({ children, forceShow = false }) {
   return (
     <>
       {loading && <Loader onComplete={handleLoadingComplete} />}
-      <div 
-        className={`transition-opacity duration-700 ${loading ? 'opacity-0' : 'opacity-100'}`}
-        style={{ visibility: loading ? 'hidden' : 'visible' }}
+      <div
+        className={`transition-opacity duration-700 ${loading ? "opacity-0" : "opacity-100"}`}
+        style={{ visibility: loading ? "hidden" : "visible" }}
       >
         {children}
       </div>

--- a/app/components/PostHogProvider.tsx
+++ b/app/components/PostHogProvider.tsx
@@ -1,23 +1,32 @@
-"use client"
+"use client";
 
-import posthog from "posthog-js"
-import { PostHogProvider as PHProvider } from "posthog-js/react"
-import { useEffect } from "react"
+import posthog from "posthog-js";
+import { PostHogProvider as PHProvider } from "posthog-js/react";
+import { useEffect } from "react";
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
-    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+    const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+    if (!apiKey) {
+      if (process.env.NODE_ENV === "development") {
+        console.warn("PostHog key is not configured. Analytics has been disabled.");
+      }
+
+      return;
+    }
+
+    posthog.init(apiKey, {
       api_host: "/ingest",
       ui_host: "https://us.posthog.com",
-      defaults: '2025-05-24',
       capture_exceptions: true, // This enables capturing exceptions using Error Tracking
       debug: process.env.NODE_ENV === "development",
-    })
-  }, [])
+    });
 
-  return (
-    <PHProvider client={posthog}>
-      {children}
-    </PHProvider>
-  )
+    return () => {
+      posthog.shutdown();
+    };
+  }, []);
+
+  return <PHProvider client={posthog}>{children}</PHProvider>;
 }

--- a/app/layout.js
+++ b/app/layout.js
@@ -52,7 +52,7 @@ export const metadata = {
 };
 
 export default function RootLayout({ children }) {
-  const isTestingLoader = true; // Change to false for production
+  const isTestingLoader = false; // Set to true only when manually testing the loader
 
   return (
     <html lang="en">

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,11 +1,6 @@
 import React from "react";
-import FolioProjectsSection from "./components/FolioProjectsSection";
-import FolioProfile from "./components/FolioProfile";
-import LandingPage from "./components/LandingPage";
 // import Hero from "./components/Hero";
 import Hero from "./components/HeroSection";
-import ProjectsSection from "./components/ProjectsSection";
-import PortfolioMockup from "./components/PortfolioMockup";
 import About from "./components/About";
 import Footer from "./components/Footer";
 import ServicesSection from "./components/Services";
@@ -13,8 +8,8 @@ import DynamicProjectsSection from "./components/DynamicProjectsSection";
 
 const Folio = () => {
   return (
-    <div className="max-w-screen overfow-hidden font-plain">
-      <div className="w-screen h-screen object-cover fixed top-0 left-0 -z-20 x-translate-y-52">
+    <div className="max-w-screen overflow-hidden font-plain">
+      <div className="w-screen h-screen object-cover fixed top-0 left-0 -z-20 -translate-y-52">
         <img
           src="/assets/sky1.webp"
           alt=""
@@ -24,19 +19,16 @@ const Folio = () => {
 
       <Hero />
       <About />
-      <section className="min-h-screen py-16 xpx-6 text-white bg-slate-800">
-        {/* <div className="min-h-[80vh] py-16 xpx-6 text-white bg-slate-800 my-auto"> */}
-          <div className="min-h-[80vh] flex flex-col items-center justify-center text-center px-4">
-            <h2 className="font-accent text-5xl md:text-6xl leading-[110%] tracking-[0.62px] mt-6">
-              Good things happen <br />
-              when you&apos;re having fun.
-            </h2>
-            <p className="text-white opacity-85 font-light text-xl mt-5 mb-10 md:mb-16 tracking-[.01em] leading-relaxed">
-              Here are some projects I&apos;ve had fun building :)
-            </p>
-          {/* </div> */}
+      <section className="min-h-screen py-16 px-6 text-white bg-slate-800">
+        <div className="min-h-[80vh] flex flex-col items-center justify-center text-center px-4">
+          <h2 className="font-accent text-5xl md:text-6xl leading-[110%] tracking-[0.62px] mt-6">
+            Good things happen <br />
+            when you&apos;re having fun.
+          </h2>
+          <p className="text-white opacity-85 font-light text-xl mt-5 mb-10 md:mb-16 tracking-[.01em] leading-relaxed">
+            Here are some projects I&apos;ve had fun building :)
+          </p>
         </div>
-        {/* <FolioProjectsSection /> */}
         <DynamicProjectsSection />
       </section>
 


### PR DESCRIPTION
## Summary
- remove unused imports and invalid Tailwind classes from the landing page to restore intended styling
- harden the hero animation, loader wrapper, and loader by cleaning up unused state, logging, and GSAP timelines
- guard PostHog initialization behind an env check, remove the stray defaults option, and switch the loader test flag off by default

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d124ddf8fc832a934f9e003680ac65